### PR TITLE
Trusted Face depends on libprotobuf-cpp-full.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -125,6 +125,10 @@ PRODUCT_PACKAGES += \
     AEXPapers \
     OmniStyle
 
+# Include explicitly to work around Facelock issues
+PRODUCT_PACKAGES += \
+    libprotobuf-cpp-full
+
 # Custom off-mode charger
 ifneq ($(WITH_CM_CHARGER),false)
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Some devices already ship it (eg RIL needs it).

Include it here to build it for every device.

Link to OpenGapps issue:
opengapps/opengapps#390