### PR TITLE
Disable Panic Mode Behaviour

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -63,5 +63,5 @@
             0 - Nothing
             1 - Go to home
     -->
-    <integer name="config_backPanicBehavior">1</integer>
+    <integer name="config_backPanicBehavior">0</integer>
 </resources>


### PR DESCRIPTION
Behaviour of panic press should be like this because panic mode is really too much pain for many users.