### PR TITLE
common: Fix Camera effects copying.

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -104,9 +104,15 @@ PRODUCT_COPY_FILES += \
     vendor/aosp/prebuilt/common/etc/init.local.rc:root/init.aosp.rc
 
 # Bring in camera effects
+ifneq ($(TARGET_COPY_OUT_VENDOR),system)
 PRODUCT_COPY_FILES +=  \
     vendor/aosp/prebuilt/common/media/LMspeed_508.emd:system/vendor/media/LMspeed_508.emd \
     vendor/aosp/prebuilt/common/media/PFFprec_600.emd:system/vendor/media/PFFprec_600.emd
+else
+PRODUCT_COPY_FILES += \
+    vendor/aosp/prebuilt/common/media/LMspeed_508.emd:system/media/LMspeed_508.emd \
+    vendor/aosp/prebuilt/common/media/PFFprec_600.emd:system/media/PFFprec_600.emd
+endif
 
 # Copy over added mimetype supported in libcore.net.MimeUtils
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
* Not all devices can have system/vendor/ directory, because they have symlink to /vendor in /system/vendor and this PRODUCT_COPY_FILES causes error.
* Devices that have TARGET_COPY_OUT_VENDOR := system should have everything copied to /system and not in /vendor or /system/vendor!
* Add if statement for it.