### PR TITLE
Add TARGET_QTI_USB_SUPPORTS_{AUDIO,DEBUG}_ACCESSORY flags

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -365,6 +365,28 @@ qti_camera_device {
 }
 
 soong_config_module_type {
+    name: "qti_usb_hal_supported_modes",
+    module_type: "cc_defaults",
+    config_namespace: "aospQcomVars",
+    bool_variables: ["supports_audio_accessory", "supports_debug_accessory"],
+    properties: [
+        "cppflags",
+    ],
+}
+
+qti_usb_hal_supported_modes {
+    name: "qti_usb_hal_supported_modes_defaults",
+    soong_config_variables: {
+        supports_audio_accessory: {
+            cppflags: ["-DSUPPORTS_AUDIO_ACCESSORY"],
+        },
+        supports_debug_accessory: {
+            cppflags: ["-DSUPPORTS_DEBUG_ACCESSORY"],
+        },
+    },
+}
+
+soong_config_module_type {
     name: "extended_compress_format",
     module_type: "cc_defaults",
     config_namespace: "aospQcomVars",

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -50,6 +50,8 @@ SOONG_CONFIG_NAMESPACES += aospQcomVars
 SOONG_CONFIG_aospQcomVars += \
     legacy_hw_disk_encryption \
     should_wait_for_qsee \
+    supports_audio_accessory \
+    supports_debug_accessory \
     supports_extended_compress_format \
     supports_hw_fde \
     supports_hw_fde_perf \
@@ -72,6 +74,8 @@ SOONG_CONFIG_aospGlobalVars_needs_netd_direct_connect_rule := $(TARGET_NEEDS_NET
 SOONG_CONFIG_aospNvidiaVars_uses_nv_enhancements := $(NV_ANDROID_FRAMEWORK_ENHANCEMENTS)
 SOONG_CONFIG_aospQcomVars_legacy_hw_disk_encryption := $(TARGET_LEGACY_HW_DISK_ENCRYPTION)
 SOONG_CONFIG_aospQcomVars_should_wait_for_qsee := $(TARGET_KEYMASTER_WAIT_FOR_QSEE)
+SOONG_CONFIG_aospQcomVars_supports_audio_accessory := $(TARGET_QTI_USB_SUPPORTS_AUDIO_ACCESSORY)
+SOONG_CONFIG_aospQcomVars_supports_debug_accessory := $(TARGET_QTI_USB_SUPPORTS_DEBUG_ACCESSORY)
 SOONG_CONFIG_aospQcomVars_supports_extended_compress_format := $(AUDIO_FEATURE_ENABLED_EXTENDED_COMPRESS_FORMAT)
 SOONG_CONFIG_aospQcomVars_supports_hw_fde := $(TARGET_HW_DISK_ENCRYPTION)
 SOONG_CONFIG_aospQcomVars_supports_hw_fde_perf := $(TARGET_HW_DISK_ENCRYPTION_PERF)


### PR DESCRIPTION
This patch will solve issue of qti_usb_hal_supported_modes_defaults author luk1337
ba8e075ed4d7cc079ab2e8a297da28df5ef3b8e7